### PR TITLE
Random Dutch license plate

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
@@ -52,6 +52,7 @@ public class HsacPluginFeatureFactory extends PluginFeatureFactoryBase {
         add(symbolProvider, new RandomEmail());
         add(symbolProvider, new RandomIban());
         add(symbolProvider, new RandomPostalCode());
+        add(symbolProvider, new RandomDutchLicensePlate());
         add(symbolProvider, new DefineDefault());
         add(symbolProvider, new DefineFromProperties());
         add(symbolProvider, new DefineDefaultFromProperties());

--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
@@ -44,8 +44,8 @@ public class RandomDutchLicensePlate extends SymbolBase implements Rule, Transla
     private String randomLicensePlate(String sideCode, String category) {
 
         int sideCodeToUse = Integer.parseInt(sideCode);
-        if (sideCodeToUse < 4 || sideCodeToUse > 10) {
-            throw new IllegalArgumentException("Only sidecodes 4 to 10 are supported!");
+        if (sideCodeToUse > 14) {
+            throw new IllegalArgumentException("Sidecodes > 14 are unsupported!");
         }
         String pattern = sidecodePatterns().get(sideCodeToUse);
         String permitted = "BDFGHJKLMNPRSTVXZ";
@@ -65,13 +65,21 @@ public class RandomDutchLicensePlate extends SymbolBase implements Rule, Transla
 
     private Map<Integer, String> sidecodePatterns() {
         Map<Integer, String> patterns = new HashMap<>();
-        patterns.put(4, "##-@@-##"); //SideCode 4
+
+        patterns.put(1, "@@-##-##"); //SideCode 1
+        patterns.put(2, "##-##-XX"); //SideCode 2
+        patterns.put(3, "##-@@-##"); //SideCode 3
+        patterns.put(4, "@@-##-@@"); //SideCode 4
         patterns.put(5, "@@-@@-##"); //SideCode 5
         patterns.put(6, "##-@@-@@"); //SideCode 6
         patterns.put(7, "##-@@@-#"); //SideCode 7
         patterns.put(8, "#-@@@-##");  //SideCode 8
         patterns.put(9, "@@-###-@");  //SideCode 9
         patterns.put(10, "@-###-@@"); //SideCode 10
+        patterns.put(11, "@@@-##-@"); //SideCode 11
+        patterns.put(12, "@-##-@@@");  //SideCode 12
+        patterns.put(13, "#-@@-###");  //SideCode 13
+        patterns.put(14, "###-@@-#"); //SideCode 14
         return patterns;
     }
 

--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
@@ -42,32 +42,33 @@ public class RandomDutchLicensePlate extends SymbolBase implements Rule, Transla
     }
 
     private String randomLicensePlate(String sideCode, String category) {
-
         int sideCodeToUse = Integer.parseInt(sideCode);
         if (sideCodeToUse > 14) {
             throw new IllegalArgumentException("Sidecodes > 14 are unsupported!");
         }
-        String pattern = sidecodePatterns().get(sideCodeToUse);
+        String licensePlate = sidecodePatterns().get(sideCodeToUse);
         String permitted = "BDFGHJKLMNPRSTVXZ";
+        String permittedFirstLetter = "FGHJKLNPRSTXZ";
 
         if (category.length() == 1) {
-            pattern = pattern.replaceFirst("@", category);
+            licensePlate = licensePlate.replaceFirst("@", category);
+        } else {
+            licensePlate = licensePlate.replaceFirst("@", RANDOM_UTIL.randomString(permittedFirstLetter, 1));
         }
-        while (pattern.contains("@")) {
-            pattern = pattern.replaceFirst("@", RANDOM_UTIL.randomString(permitted, 1));
+        while (licensePlate.contains("@")) {
+            licensePlate = licensePlate.replaceFirst("@", RANDOM_UTIL.randomString(permitted, 1));
         }
-        while (pattern.contains("#")) {
-            pattern = pattern.replaceFirst("#", RANDOM_UTIL.randomString("1234567890", 1));
+        while (licensePlate.contains("#")) {
+            licensePlate = licensePlate.replaceFirst("#", RANDOM_UTIL.randomString("1234567890", 1));
         }
-        return pattern;
-
+        return licensePlate;
     }
 
     private Map<Integer, String> sidecodePatterns() {
         Map<Integer, String> patterns = new HashMap<>();
 
         patterns.put(1, "@@-##-##"); //SideCode 1
-        patterns.put(2, "##-##-XX"); //SideCode 2
+        patterns.put(2, "##-##-@@"); //SideCode 2
         patterns.put(3, "##-@@-##"); //SideCode 3
         patterns.put(4, "@@-##-@@"); //SideCode 4
         patterns.put(5, "@@-@@-##"); //SideCode 5
@@ -80,7 +81,7 @@ public class RandomDutchLicensePlate extends SymbolBase implements Rule, Transla
         patterns.put(12, "@-##-@@@");  //SideCode 12
         patterns.put(13, "#-@@-###");  //SideCode 13
         patterns.put(14, "###-@@-#"); //SideCode 14
+
         return patterns;
     }
-
 }

--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
@@ -1,0 +1,78 @@
+package nl.hsac.fitnesse.symbols;
+
+import fitnesse.wikitext.parser.*;
+import nl.hsac.fitnesse.util.RandomUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Generates random Dutch license plates.
+ * Usage: !randomDutchLicensePlate (Category) (Sidecode)
+ * Sidecodes 4-10 are supported (see: https://nl.wikipedia.org/wiki/Nederlands_kenteken)
+ * Sidecode 7 is used by default.
+ * Category expects a single letter that is used as the first letter in the license plate
+ * (f.e. D for mopeds, M for Motorcycle, V for light company cars, B for heavy company cars (>3500KG))
+ */
+public class RandomDutchLicensePlate extends SymbolBase implements Rule, Translation {
+
+    private static final RandomUtil RANDOM_UTIL = new RandomUtil();
+    private static final String CATEGORY = "Category";
+    private static final String SIDECODE = "Sidecode";
+
+    public RandomDutchLicensePlate() {
+        super("RandomDutchLicensePlate");
+        wikiMatcher(new Matcher().string("!randomDutchLicensePlate"));
+        wikiRule(this);
+        htmlTranslation(this);
+    }
+
+    public Maybe<Symbol> parse(Symbol current, Parser parser) {
+        Maybe<Symbol> result = storeParenthesisContent(current, parser, CATEGORY);
+        if (!result.isNothing()) {
+            result = storeParenthesisContent(current, parser, SIDECODE);
+        }
+        return result;
+    }
+
+    public String toTarget(Translator translator, Symbol symbol) {
+        String category = symbol.getProperty(CATEGORY, "");
+        String sideCode = symbol.getProperty(SIDECODE, "7");
+        return randomLicensePlate(sideCode, category.toUpperCase());
+    }
+
+    private String randomLicensePlate(String sideCode, String category) {
+
+        int sideCodeToUse = Integer.parseInt(sideCode);
+        if (sideCodeToUse < 4 || sideCodeToUse > 10) {
+            throw new IllegalArgumentException("Only sidecodes 4 to 10 are supported!");
+        }
+        String pattern = sidecodePatterns().get(sideCodeToUse);
+        String permitted = "BDFGHJKLMNPRSTVXZ";
+
+        if (category.length() == 1) {
+            pattern = pattern.replaceFirst("@", category);
+        }
+        while (pattern.contains("@")) {
+            pattern = pattern.replaceFirst("@", RANDOM_UTIL.randomString(permitted, 1));
+        }
+        while (pattern.contains("#")) {
+            pattern = pattern.replaceFirst("#", RANDOM_UTIL.randomString("1234567890", 1));
+        }
+        return pattern;
+
+    }
+
+    private Map<Integer, String> sidecodePatterns() {
+        Map<Integer, String> patterns = new HashMap<>();
+        patterns.put(4, "##-@@-##"); //SideCode 4
+        patterns.put(5, "@@-@@-##"); //SideCode 5
+        patterns.put(6, "##-@@-@@"); //SideCode 6
+        patterns.put(7, "##-@@@-#"); //SideCode 7
+        patterns.put(8, "#-@@@-##");  //SideCode 8
+        patterns.put(9, "@@-###-@");  //SideCode 9
+        patterns.put(10, "@-###-@@"); //SideCode 10
+        return patterns;
+    }
+
+}

--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * Generates random Dutch license plates.
  * Usage: !randomDutchLicensePlate (Category) (Sidecode)
- * Sidecodes 4-10 are supported (see: https://nl.wikipedia.org/wiki/Nederlands_kenteken)
+ * Sidecodes 1-14 are supported (see: https://nl.wikipedia.org/wiki/Nederlands_kenteken)
  * Sidecode 7 is used by default.
  * Category expects a single letter that is used as the first letter in the license plate
  * (f.e. D for mopeds, M for Motorcycle, V for light company cars, B for heavy company cars (>3500KG))


### PR DESCRIPTION
Added the symbol randomDutchLicensePlate to generate license plates that have a valid format.
Usage: !randomDutchLicensePlate (category) (sidecode)

Category has an empty default and is used to determine the first letter on the plate. (any passenger car if empty)
Sidecode defaults to sidecode 7, because that is the most recent sidecode that exists and contains all categories (Motorcycle, Moped, Light & Heavy company cars)

Note that special combinations such as AA, KL or unused combinations (mostly acronyms) are not filtered. Might be useful later, but I have no current use case for it.