### PR TITLE
Prevent arguments to be missed when a table template row calls a scenario

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/slim/AutoArgScenarioTable.java
+++ b/src/main/java/nl/hsac/fitnesse/slim/AutoArgScenarioTable.java
@@ -63,11 +63,10 @@ public class AutoArgScenarioTable extends ScenarioTable {
             ScenarioTable calledScenario = getCalledScenario(columnCount - 1, row);
             if (calledScenario != null) {
                 addNestedScenarioArguments(found, pattern == ARG_PATTERN, calledScenario);
-            } else {
-                for (int column = 0; column < columnCount; column++) {
-                    String cellContent = table.getCellContents(column, row);
-                    addAllMatches(pattern, found, cellContent);
-                }
+            }
+            for (int column = 0; column < columnCount; column++) {
+                String cellContent = table.getCellContents(column, row);
+                addAllMatches(pattern, found, cellContent);
             }
         }
         return found;


### PR DESCRIPTION
Also scan the current table row if calls a nested scenario, preventing input args to be missed when the scenario that is called has a different name for the argument.

Please review. All my tests and reproduction from #33 and #34 seem to be OK this way, but there may be corner cases..