### PR TITLE
Add !uuid as a wiki symbol to generate a UUID

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
@@ -57,6 +57,7 @@ public class HsacPluginFeatureFactory extends PluginFeatureFactoryBase {
         add(symbolProvider, new DefineDefault());
         add(symbolProvider, new DefineFromProperties());
         add(symbolProvider, new DefineDefaultFromProperties());
+        add(symbolProvider, new Uuid());
     }
 
     private void add(SymbolProvider provider, SymbolType symbolType) {

--- a/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/HsacPluginFeatureFactory.java
@@ -57,7 +57,7 @@ public class HsacPluginFeatureFactory extends PluginFeatureFactoryBase {
         add(symbolProvider, new DefineDefault());
         add(symbolProvider, new DefineFromProperties());
         add(symbolProvider, new DefineDefaultFromProperties());
-        add(symbolProvider, new Uuid());
+        add(symbolProvider, new RandomUuid());
     }
 
     private void add(SymbolProvider provider, SymbolType symbolType) {

--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomUuid.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomUuid.java
@@ -3,11 +3,11 @@ package nl.hsac.fitnesse.symbols;
 import fitnesse.wikitext.parser.*;
 import java.util.UUID;
 
-public class Uuid extends SymbolBase implements Rule, Translation {
+public class RandomUuid extends SymbolBase implements Rule, Translation {
 
-    public Uuid() {
+    public RandomUuid() {
         super("Uuid");
-        wikiMatcher(new Matcher().string("!uuid"));
+        wikiMatcher(new Matcher().string("!randomUuid"));
         wikiRule(this);
         htmlTranslation(this);
     }

--- a/src/main/java/nl/hsac/fitnesse/symbols/Uuid.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/Uuid.java
@@ -1,0 +1,24 @@
+package nl.hsac.fitnesse.symbols;
+
+import fitnesse.wikitext.parser.*;
+import java.util.UUID;
+
+public class Uuid extends SymbolBase implements Rule, Translation {
+
+    public Uuid() {
+        super("Uuid");
+        wikiMatcher(new Matcher().string("!uuid"));
+        wikiRule(this);
+        htmlTranslation(this);
+    }
+
+    @Override
+    public Maybe<Symbol> parse(Symbol current, Parser parser) {
+        return new Maybe<>(current);
+    }
+
+    @Override
+    public String toTarget(Translator translator, Symbol symbol) {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/test/wiki/FitNesseRoot/HsacPlugin/Symbols.wiki
+++ b/src/test/wiki/FitNesseRoot/HsacPlugin/Symbols.wiki
@@ -38,4 +38,4 @@ Some extra Wiki symbols that can be used:
 |random Iban (country code)                                                       |{{{!-!randomIBAN (FR)-! }}}                                   |!randomIBAN (FR)                                       |
 |random Postal Code (using default NL)                                            |{{{!-!randomPostalCode-! }}}                                  |!randomPostalCode                                      |
 |random Postal Code (possible: AU, BE, BR, CA, CH, DE, GL, FR, IT, NL, NO, US)    |{{{!-!randomPostalCode (FR)-! }}}                             |!randomPostalCode (FR)                                 |
-|Universally unique identifier (UUID)                                             |{{{!-!uuid-! }}}                                              |!uuid                                                  |
+|random universally unique identifier (UUID)                                      |{{{!-!randomUuid-! }}}                                        |!randomUuid                                            |

--- a/src/test/wiki/FitNesseRoot/HsacPlugin/Symbols.wiki
+++ b/src/test/wiki/FitNesseRoot/HsacPlugin/Symbols.wiki
@@ -38,3 +38,4 @@ Some extra Wiki symbols that can be used:
 |random Iban (country code)                                                       |{{{!-!randomIBAN (FR)-! }}}                                   |!randomIBAN (FR)                                       |
 |random Postal Code (using default NL)                                            |{{{!-!randomPostalCode-! }}}                                  |!randomPostalCode                                      |
 |random Postal Code (possible: AU, BE, BR, CA, CH, DE, GL, FR, IT, NL, NO, US)    |{{{!-!randomPostalCode (FR)-! }}}                             |!randomPostalCode (FR)                                 |
+|Universally unique identifier (UUID)                                             |{{{!-!uuid-! }}}                                              |!uuid                                                  |


### PR DESCRIPTION
Got this request from a few different projects. Can be achieved with randomstring, but generating a properly formatted (8-4-4-4-12) UUID using !uuid is much more convenient.