### PR TITLE
Remove characters that are not always valid from permitted String for Random Licenceplate

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
+++ b/src/main/java/nl/hsac/fitnesse/symbols/RandomDutchLicensePlate.java
@@ -47,7 +47,7 @@ public class RandomDutchLicensePlate extends SymbolBase implements Rule, Transla
             throw new IllegalArgumentException("Sidecodes > 14 are unsupported!");
         }
         String licensePlate = sidecodePatterns().get(sideCodeToUse);
-        String permitted = "BDFGHJKLMNPRSTVXZ";
+        String permitted = "BGHJKLNPRSTVXZ";
         String permittedFirstLetter = "FGHJKLNPRSTXZ";
 
         if (category.length() == 1) {


### PR DESCRIPTION
Remove letters that are not valid for all sidecodes from permitted string